### PR TITLE
update  C++ Concurrency in Action link

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ C++2.0 是一个简称，意为「现代 C++」，包括 C++11/14/17/20。
 - [第一章](./concurrency/concurrency_v1/chapter1)
 - [第二章](./concurrency/concurrency_v1/chapter2)
 
-学习资料：https://chenxiaowei.gitbook.io/cpp_concurrency_in_action/
+学习资料：https://downdemo.gitbook.io/cpp-concurrency-in-action-2ed/
 
 #### 6.2 多线程与多进程
 


### PR DESCRIPTION
The link https://chenxiaowei.gitbook.io/cpp_concurrency_in_action/ for cpp concurrency in action is archived by the author and can not be reachable. I find the updated version here https://github.com/xiaoweiChen/CPP-Concurrency-In-Action-2ed-2019 with the same user.
![image](https://user-images.githubusercontent.com/10331871/92989205-5d38fe80-f487-11ea-9562-0bd6e8514fef.png)



