### PR TITLE
修复设计模式-单例的一些错误

### DIFF
--- a/design_pattern/singleton/README.md
+++ b/design_pattern/singleton/README.md
@@ -114,7 +114,7 @@ private:
     static singleton *p;
     static mutex lock_;
 public:
-    singleton *instance();
+    static singleton *instance();
 
     // 实现一个内嵌垃圾回收类
     class CGarbo
@@ -131,6 +131,7 @@ public:
 
 singleton *singleton::p = nullptr;
 singleton::CGarbo Garbo;
+std::mutex singleton::lock_;
 
 singleton* singleton::instance() {
     if (p == nullptr) {

--- a/design_pattern/singleton/dcl_singleton.cpp
+++ b/design_pattern/singleton/dcl_singleton.cpp
@@ -14,7 +14,7 @@ private:
     static singleton *p;
     static mutex lock_;
 public:
-    singleton *instance();
+    static singleton *instance();
 
     // 实现一个内嵌垃圾回收类
     class CGarbo
@@ -31,6 +31,7 @@ public:
 
 singleton *singleton::p = nullptr;
 singleton::CGarbo Garbo;
+std::mutex singleton::lock_;
 
 singleton* singleton::instance() {
     if (p == nullptr) {

--- a/design_pattern/singleton/static_local_singleton.cpp
+++ b/design_pattern/singleton/static_local_singleton.cpp
@@ -11,12 +11,12 @@ private:
     static singleton *p;
     singleton() {}
 public:
-    singleton *instance();
+    static singleton &instance();
 };
 
-singleton *singleton::instance() {
+singleton &singleton::instance() {
     static singleton p;
-    return &p;
+    return p;
 }
 
 

--- a/design_pattern/singleton/static_local_singleton.cpp
+++ b/design_pattern/singleton/static_local_singleton.cpp
@@ -1,5 +1,7 @@
 //
 // Created by light on 20-2-7.
+// 在C++11标准下，《Effective C++》提出了一种更优雅的单例模式实现，使用函数内的 local static 对象。
+// 这种方法也被称为Meyers' Singleton。
 //
 
 #include <iostream>
@@ -8,7 +10,6 @@ using namespace std;
 
 class singleton {
 private:
-    static singleton *p;
     singleton() {}
 public:
     static singleton &instance();


### PR DESCRIPTION
1.修复漏掉的static
2.测试发现，mutex也需要声明，否则会报`error: undefined reference to ‘....' ` 和 `error: collect2.exe: error: ld returned 1 exit status`  错误
3.Meyers' Singleton应为&，static singleton* instance()这样做并不好，无法避免用户使用delete instance导致对象被提前销毁。建议使用返回引用的方式。