### PR TITLE
Conflict of ~~ and **

### DIFF
--- a/basic_content/const/README.md
+++ b/basic_content/const/README.md
@@ -19,7 +19,7 @@ const int a=100;
 + 类型检查
 
     + const常量与`#define`宏定义常量的区别：
-    > ~~<u>**const常量具有类型，编译器可以进行安全检查；#define宏定义没有数据类型，只是简单的字符串替换，不能进行安全检查。**</u>~~感谢两位大佬指出这里问题，见：[issue](https://github.com/Light-City/CPlusPlusThings/issues/5)
+    > **<s>const常量具有类型，编译器可以进行安全检查；#define宏定义没有数据类型，只是简单的字符串替换，不能进行安全检查。</s>**感谢两位大佬指出这里问题，见：[issue](https://github.com/Light-City/CPlusPlusThings/issues/5)
 
     + const常量支持所有类型。
     + 其他情况下它只是一个 `const` 限定的变量，不要将与常量混淆。

--- a/basic_content/const/README.md
+++ b/basic_content/const/README.md
@@ -19,7 +19,7 @@ const int a=100;
 + 类型检查
 
     + const常量与`#define`宏定义常量的区别：
-    > **<s>const常量具有类型，编译器可以进行安全检查；#define宏定义没有数据类型，只是简单的字符串替换，不能进行安全检查。</s>**感谢两位大佬指出这里问题，见：[issue](https://github.com/Light-City/CPlusPlusThings/issues/5)
+    > <strong><s>const常量具有类型，编译器可以进行安全检查；#define宏定义没有数据类型，只是简单的字符串替换，不能进行安全检查。</s></strong>感谢两位大佬指出这里问题，见：[issue](https://github.com/Light-City/CPlusPlusThings/issues/5)
 
     + const常量支持所有类型。
     + 其他情况下它只是一个 `const` 限定的变量，不要将与常量混淆。


### PR DESCRIPTION
markdown语法中的 ~~删除线~~ 和 **加粗**连用时不能在github中正确预览(~~**奇怪的是在这里可以正确显示**~~)，使用html标签替换了basic_content/const/README.md中的一处使用。