### PR TITLE
Fix typo: smater_ptr -> smart_ptr

### DIFF
--- a/learn_class/modern_cpp_30/smart_ptr/README.md
+++ b/learn_class/modern_cpp_30/smart_ptr/README.md
@@ -33,12 +33,12 @@ private:
 
 ```cpp
 template <typename  T>
-class smater_ptr {
+class smart_ptr {
 public:
-    explicit smater_ptr(
+    explicit smart_ptr(
             T* ptr = nullptr)
             : ptr_(ptr) {}
-    ~smater_ptr()
+    ~smart_ptr()
     {
         delete ptr_;
     }
@@ -54,7 +54,7 @@ private:
 
 ```cpp
 template <typename  T>
-class smater_ptr {
+class smart_ptr {
 public:
    	...
     T& operator*() const { return *ptr_; }


### PR DESCRIPTION
### Description
This pull request fixes a typo in the smater_ptr implementation. The class name has been corrected to smarter_ptr, which better reflects its purpose and adheres to proper naming conventions.

### Changes Made
Renamed smater_ptr to smarter_ptr in the README.md file.
No functional changes were introduced.

### Reason for Change
The original name smater_ptr appears to be a typo and does not align with the intended meaning of a "smart pointer."