### PR TITLE
修复简单typo

### DIFF
--- a/basic_content/sizeof/geninhe.cpp
+++ b/basic_content/sizeof/geninhe.cpp
@@ -49,7 +49,7 @@ class C {
 class A1 {
   virtual void fun() {}
 };
-class C1 : public A {};
+class C1 : public A1 {};
 
 int main() {
   cout << sizeof(A) << endl; // 8


### PR DESCRIPTION
sizeof 章节 关于具有虚函数的类的继承的示范代码有误.

https://github.com/Light-City/CPlusPlusThings/blob/c9d0f14d92976a5aa65819e9543e2f812d4079ba/basic_content/sizeof/geninhe.cpp#L49-L52

https://github.com/Light-City/CPlusPlusThings/blob/c9d0f14d92976a5aa65819e9543e2f812d4079ba/basic_content/sizeof/geninhe.cpp#L15-L19

此处的 `A` 不是具有虚函数的类，`C1` 正确是示范应是继承 `A1`