### PR TITLE
Fix bug on initializing class member reference

### DIFF
--- a/codingStyleIdioms/1_classInitializers/1.3_const.cpp
+++ b/codingStyleIdioms/1_classInitializers/1.3_const.cpp
@@ -7,7 +7,7 @@
 
 class Animal {
 public:
-    Animal(int age,std::string name):age_(age),name_(name) {
+    Animal(int& age,std::string name):age_(age),name_(name) {
         std::cout << "Animal(int age) is called" << std::endl;
     }
 private:
@@ -16,6 +16,7 @@ private:
 };
 
 int main() {
-    Animal animal(10,"hh");
+    int x = 10;
+    Animal animal(x,"hh");
     return 0;
 }


### PR DESCRIPTION
https://github.com/Light-City/CPlusPlusThings/blob/c9d0f14d92976a5aa65819e9543e2f812d4079ba/codingStyleIdioms/1_classInitializers/1.3_const.cpp#L6-L21

The original code is wrong. Here class memebr reference variable `age_` is binding to constructor parameter `age`, which is passed by value. When the constructor finishes, this variable goes out of scope, and the binded refernce `age_` is dangling. All subsequent usage of `age_` is undefined behaviour